### PR TITLE
Added maxCO2 to suppress erroneous high (13850) CO2 levels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # VCO100 library for the Voltcraft CO-100
-This library provides a class for reading temperature, relative humidity and CO2 level from the Voltcraft CO-100 air quality measuring device.
+This library provides a class for reading temperature, relative humidity and CO2 level from the Voltcraft CO-100 air quality measuring device. It has been reported that it also works on the Voltcraft CO-60, although I have not been able to confirm that myself.
 
 ## Target systems
-The code is written for the Arduino and Digistump Oak. It should be possible to run this on many other devices as well.
+The code is written for the Arduino and Digistump Oak, an ESP8266 device. It should be possible to run this on many other devices as well.
 
 ## Examples
 The code comes with two examples that read the data from the CO-100:

--- a/examples/OakExampleMQTT/OakExampleMQTT.ino
+++ b/examples/OakExampleMQTT/OakExampleMQTT.ino
@@ -52,9 +52,9 @@ PubSubClient client(espClient);
 #define DELAY_BETWEEN_CONNECTS_MILLIS 5000  // time between MQTT reconnect attempts
 
 
-const float tempOffset = 1.0;     // Temp indication on the device seems to be on the high side.
+const float tempOffset = 1.0;   // Temp indication on the device seems to be on the high side.
 const int humOffset = -5.0;     // Humidity indication on the device seems to be on the low side.
-
+const int maxCO2 = 5000;        // only to suppress erratic high values
 
 /*
    Domoticz configuration
@@ -145,7 +145,7 @@ void loop() {
          - if data is valid
          - if data has changed enough wrt. previous values to prevent flapping and too much data accumulation
       */
-      if (cotwo && ( abs(cotwo - prefCotwo) >= 5) ) {
+      if (cotwo && cotwo < maxCO2 && ( abs(cotwo - prefCotwo) >= 5)) {
         static char outstr[5];
         dtostrf(cotwo, sizeof(cotwo), 0, outstr);  // convert float to string
         snprintf (msg, 50, "{\"name\":\"Voltcraft CO2\",\"idx\":%i,\"nvalue\":%s}", domoIdxCO2, outstr); // format output message


### PR DESCRIPTION
Three times in a few weeks I saw the CO2 value 13850 being logged.
Seems either a bug in the Voltcraft, in my code or in Domoticz.

Added a maxCO2 value in the MQTT example. If the high value does not occur anymore I know the bug is not in Domoticz. 
